### PR TITLE
calendar view page

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,5 @@
+
+<!-- href is url to apps script form -->
+<a href="https://script.google.com/a/macros/scottnath.com/s/AKfycby1O3mz9DIyhx1b80ro1vnHioJcO_pyFiBQl7AG_Q8RoQEpF9I/exec">Add an appointment</a>
+
+<iframe src="https://www.google.com/calendar/embed?src=scottnath.com_egim4s6u6q9u672aqmlu79o444%40group.calendar.google.com&ctz=America/New_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Hi @EduardoDuarte 

I'm adding this html page to solve help solve the workflow part of the original request as it looks like getting the calendar to show in google apps will not work. 
## workflow
1. user views the calendar **(./calendar.html solves this)**
2. to add a new event a user clicks a link which says "add new appointment"  **(./calendar.html solves this)**
3. clicking brings the user to the add event form  **(./calendar.html solves this)**
4. user adds a new event using the form
5. upon successful form submission:
6. event is added to the calendar
7. calendar owner is sent an email with the event details
8. user is redirected to the calendar interface **NOTE: missing functionality**
9. user can see their new event in the calendar as "busy"
## What needs to happen

Upon successful submission, user should be redirected to a configurable, non-google-apps-script url.
If it is possible to send the submitted parameters that would be great, but it is not a requirement.

Hope this helps,
Scott
